### PR TITLE
fix: Add path fallbacks and policy content injection in 3-level-flow

### DIFF
--- a/scripts/3-level-flow.py
+++ b/scripts/3-level-flow.py
@@ -2286,7 +2286,12 @@ Work to complete: Execute phase {i} of the identified work breakdown.
         })
         print(f"   [{step_num}] {step_name}: Active")
 
-    # Inject version-release enforcement into output (Claude sees this)
+    # =========================================================================
+    # POLICY ENFORCEMENT OUTPUT: Print critical rules to stdout (Claude reads these)
+    # Only rules NOT auto-enforced by scripts — Claude must follow these directly.
+    # =========================================================================
+
+    # Version-release policy
     if 'version-release-policy' in loaded_policies.get('level-3', {}):
         print()
         print("[ENFORCE] VERSION-RELEASE POLICY (from policies/03-execution-system/09-git-commit/):")
@@ -2296,6 +2301,53 @@ Work to complete: Execute phase {i} of the identified work breakdown.
         print("   3. Commit version bump + push")
         print("   4. Create GitHub Release (gh release create) for IDE")
         print("   5. Ensure version consistency across README/CLAUDE.md/badges")
+
+    # Task breakdown policy (not auto-enforced — Claude must use TaskCreate)
+    if 'automatic-task-breakdown-policy' in loaded_policies.get('level-3', {}):
+        print()
+        print("[ENFORCE] TASK BREAKDOWN POLICY:")
+        print("   1. ALWAYS create tasks via TaskCreate on EVERY coding request (minimum 1)")
+        print("   2. Break complex tasks into phases (Foundation, Logic, API, Config)")
+        print("   3. Mark tasks completed via TaskUpdate when done")
+        print("   4. Create task dependencies if needed (blockedBy/blocks)")
+
+    # Model selection policy (not auto-enforced — Claude must route correctly)
+    if 'model-selection-enforcement' in loaded_policies.get('level-3', {}) or \
+       'intelligent-model-selection-policy' in loaded_policies.get('level-3', {}):
+        print()
+        print("[ENFORCE] MODEL SELECTION POLICY:")
+        print("   1. Search/explore tasks -> Use Agent(Explore, model=haiku)")
+        print("   2. Architecture/design tasks -> Use Agent(Plan, model=opus)")
+        print("   3. Implementation tasks -> Use current model (Sonnet/Opus)")
+        print("   4. Simple tasks (grep, read) -> Use model=haiku for subagents")
+
+    # Tool optimization policy (partially auto-enforced — these rules need Claude awareness)
+    if 'tool-usage-optimization-policy' in loaded_policies.get('level-3', {}):
+        print()
+        print("[ENFORCE] TOOL OPTIMIZATION POLICY:")
+        print("   1. Add head_limit to EVERY Grep call (default: 100)")
+        print("   2. Use offset/limit for files >500 lines (Read tool)")
+        print("   3. NEVER use 'tree' command - use Glob or 'find' instead")
+        print("   4. Combine sequential Bash commands with && in a single call")
+
+    # Failure prevention policy (partially auto-enforced — Unicode rule needs Claude)
+    if 'common-failures-prevention' in loaded_policies.get('level-3', {}):
+        print()
+        print("[ENFORCE] FAILURE PREVENTION POLICY:")
+        print("   1. NO Unicode/emojis in Python files on Windows (use ASCII: [OK], [WARN])")
+        print("   2. Strip line number prefixes before Edit (remove '  123->' patterns)")
+        print("   3. Quote all file paths containing spaces")
+        print("   4. Auto-translate: del->rm, copy->cp, dir->ls in Bash")
+
+    # Coding standards policy (not auto-enforced — Claude must follow in code generation)
+    if loaded_policies.get('level-2', {}):
+        print()
+        print("[ENFORCE] CODING STANDARDS (Level 2):")
+        print("   1. NO hardcoded strings - use constants (MessageConstants, ApiConstants)")
+        print("   2. ALL API responses use ApiResponseDto<T> wrapper")
+        print("   3. Service implementations are package-private, extend Helper classes")
+        print("   4. Config Server ONLY for DB/Redis/Feign config (never in application.yml)")
+        print("   5. Secrets via Secret Manager: ${SECRET:key-name} syntax")
 
     print("[OK] LEVEL 3 COMPLETE (All 12 steps executed)")
     print()


### PR DESCRIPTION
## Summary
- Fixed 6 path fallback locations in 3-level-flow.py for Level 2 and Level 3 scripts (standards-loader.py, prompt-generator.py, task-auto-analyzer.py, auto-plan-mode-suggester.py, pre-execution-checker.py)
- Added [ENFORCE] blocks that inject critical policy rules into Claude's context via stdout (Task Breakdown, Model Selection, Tool Optimization, Failure Prevention, Coding Standards)
- Root cause: scripts looked in `~/.claude/memory/0X-system/` but are deployed at `~/.claude/scripts/architecture/0X-system/` — Level 1 had fallbacks, Level 2 and 3 did not

## Test plan
- [x] Syntax verified via py_compile
- [ ] Verify Level 2 standards-loader.py is found and executes
- [ ] Verify [ENFORCE] blocks appear in hook output
- [ ] Verify Level 3 steps 3.0, 3.1, 3.2, 3.5, 3.7 find their scripts

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)