### PR TITLE
fix: remove hardcoded paths + improve auto-commit messages

### DIFF
--- a/scripts/agents/computer-use-preflight-checklist.md
+++ b/scripts/agents/computer-use-preflight-checklist.md
@@ -21,7 +21,7 @@ TOTAL:                         25 policies PASSED
 
 **Verification:**
 ```bash
-cd ~/Documents/workspace-spring-tool-suite-4-4.27.0-new/claude-insight
+cd "$(git rev-parse --show-toplevel)"  # auto-detect project root
 python scripts/3-level-flow.py --summary
 
 # Expected output:
@@ -78,7 +78,7 @@ Check:    jq '.completion_percentage' work-summary.json → Should show >=95%
 
 #### A. Dashboard Startup
 ```bash
-cd ~/Documents/workspace-spring-tool-suite-4-4.27.0-new/claude-insight
+cd "$(git rev-parse --show-toplevel)"  # auto-detect project root
 python run.py
 
 # Expected:

--- a/scripts/architecture/03-execution-system/09-git-commit/git-auto-commit-policy.py
+++ b/scripts/architecture/03-execution-system/09-git-commit/git-auto-commit-policy.py
@@ -655,8 +655,30 @@ class GitAutoCommitAI:
 
         return "chore"
 
+    def _describe_files(self, file_list, max_names=3):
+        """Build a readable description of changed files.
+
+        Args:
+            file_list: List of file paths.
+            max_names: Max number of file names to include.
+
+        Returns:
+            str: e.g. "stop-notifier, git_operations" or "3 langgraph_engine modules"
+        """
+        if not file_list:
+            return "files"
+        stems = [Path(f).stem for f in file_list]
+        # If all files share a common directory, mention it
+        dirs = set(str(Path(f).parent) for f in file_list)
+        if len(file_list) <= max_names:
+            return ", ".join(stems)
+        if len(dirs) == 1:
+            dirname = Path(list(dirs)[0]).name
+            return f"{len(file_list)} {dirname} modules"
+        return f"{len(file_list)} files"
+
     def generate_summary(self, changes, commit_type):
-        """Generate first line of commit message.
+        """Generate first line of commit message with meaningful file context.
 
         Args:
             changes:      Dict from analyze_changes().
@@ -669,38 +691,41 @@ class GitAutoCommitAI:
             return "update files"
 
         if commit_type == "feat":
-            if len(changes.get("added", [])) == 1:
-                filename = Path(changes["added"][0]).stem
-                return f"add {filename}"
-            else:
-                return f"add {len(changes.get('added', []))} new files"
+            desc = self._describe_files(changes.get("added", []))
+            return f"add {desc}"
 
         elif commit_type == "fix":
-            if len(changes.get("modified", [])) == 1:
-                filename = Path(changes["modified"][0]).stem
-                return f"fix issue in {filename}"
-            else:
-                return f"fix issues in {len(changes.get('modified', []))} files"
+            desc = self._describe_files(changes.get("modified", []))
+            return f"fix {desc}"
 
         elif commit_type == "refactor":
             if changes.get("deleted"):
-                return f"remove {len(changes['deleted'])} files"
+                desc = self._describe_files(changes.get("deleted", []))
+                return f"remove {desc}"
             else:
-                return f"refactor {len(changes.get('modified', []))} files"
+                desc = self._describe_files(changes.get("modified", []))
+                return f"refactor {desc}"
 
         elif commit_type == "test":
-            return "update tests"
+            desc = self._describe_files(
+                changes.get("added", []) + changes.get("modified", [])
+            )
+            return f"update tests in {desc}"
 
         elif commit_type == "docs":
-            return "update documentation"
+            desc = self._describe_files(
+                changes.get("added", []) + changes.get("modified", [])
+            )
+            return f"update docs: {desc}"
 
         else:
-            total = (
-                len(changes.get("added", []))
-                + len(changes.get("modified", []))
-                + len(changes.get("deleted", []))
+            all_files = (
+                changes.get("added", [])
+                + changes.get("modified", [])
+                + changes.get("deleted", [])
             )
-            return f"update {total} files"
+            desc = self._describe_files(all_files)
+            return f"update {desc}"
 
     def generate_details(self, changes):
         """Generate detailed description for commit body.

--- a/scripts/github_pr_workflow.py
+++ b/scripts/github_pr_workflow.py
@@ -295,12 +295,19 @@ def _commit_session_changes(repo_root: str, session_summary: dict,
             _log(f"git add failed: {result.stderr[:200]}")
             return False
 
-        # Build commit message from session summary
-        commit_title = "Session work"
+        # Build commit message from session summary + actual changed files
+        commit_title = ""
         commit_body = ""
 
+        # Get list of staged files for context
+        diff_result = subprocess.run(
+            ['git', 'diff', '--cached', '--name-only'],
+            capture_output=True, text=True, timeout=10, cwd=repo_root
+        )
+        changed_files = [f for f in diff_result.stdout.strip().splitlines() if f] if diff_result.returncode == 0 else []
+
         if session_summary:
-            # Use task types and skills for a descriptive title
+            # Use task types for commit type prefix
             types = session_summary.get('task_types', [])
             if types:
                 commit_title = ', '.join(types[:3])
@@ -315,6 +322,29 @@ def _commit_session_changes(repo_root: str, session_summary: dict,
                         body_lines.append(f"- {prompt}")
                 if body_lines:
                     commit_body = '\n'.join(body_lines[:10])
+
+        # Generate descriptive title from changed files if no session summary
+        if not commit_title and changed_files:
+            stems = [Path(f).stem for f in changed_files[:3]]
+            if len(changed_files) <= 3:
+                commit_title = f"update {', '.join(stems)}"
+            else:
+                # Group by directory for context
+                dirs = set(str(Path(f).parent) for f in changed_files)
+                if len(dirs) == 1:
+                    dirname = Path(list(dirs)[0]).name
+                    commit_title = f"update {len(changed_files)} {dirname} modules"
+                else:
+                    commit_title = f"update {', '.join(stems)} and {len(changed_files) - 3} more"
+        elif not commit_title:
+            commit_title = "update implementation"
+
+        # Add file list to body for traceability
+        if changed_files and not commit_body:
+            commit_body = "Modified files ({}):\n{}".format(
+                len(changed_files),
+                '\n'.join(f"  - {f}" for f in changed_files[:10])
+            )
 
         # Append Closes #N for auto-closing GitHub issues (policy requirement)
         if issue_numbers:

--- a/scripts/session-summary-manager.py
+++ b/scripts/session-summary-manager.py
@@ -373,8 +373,7 @@ def _extract_project(cwd):
     # Fallback: last non-generic directory name
     for part in reversed(parts):
         if part not in ('backend', 'frontend', 'src', 'main', 'java', 'resources',
-                        'Documents', 'Users', 'workspace-spring-tool-suite-4-4.27.0-new',
-                        'C:', 'c'):
+                        'Documents', 'Users', 'C:', 'c') and 'workspace-' not in part:
             return part
     return None
 

--- a/scripts/smart-sync-to-claude-insight.sh
+++ b/scripts/smart-sync-to-claude-insight.sh
@@ -24,7 +24,8 @@
 set -e
 
 MEMORY_PATH="$HOME/.claude/memory"
-CLAUDE_INSIGHT_PATH="/c/Users/techd/Documents/workspace-spring-tool-suite-4-4.27.0-new/claude-insight"
+# Auto-detect project path from git root or fallback to env var
+CLAUDE_INSIGHT_PATH="${CLAUDE_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/claude-workflow-engine")}"
 DETECTOR="$MEMORY_PATH/current/detect-sync-eligibility.py"
 
 # Colors


### PR DESCRIPTION
## Summary
- Remove last 4 hardcoded workspace paths from non-critical files
- Improve auto-commit message generator to use actual file names instead of "update N files"

## Changes
- `git-auto-commit-policy.py`: New `_describe_files()` method generates meaningful summaries
- `github_pr_workflow.py`: Commit titles from changed file stems, file list in body
- `computer-use-preflight-checklist.md`: Dynamic git root detection
- `session-summary-manager.py`: Generic workspace filter
- `smart-sync-to-claude-insight.sh`: Use env var for project path

## Before/After
```
Before: "chore: update 4 files"
After:  "chore: update stop-notifier, git_operations, level3_steps8to12_github"
```

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)