### PR TITLE
fix(level-minus1): require 2-char path segment min + restore OPTIONS:\n (#229 #225)

### DIFF
--- a/langgraph_engine/level_minus1/nodes.py
+++ b/langgraph_engine/level_minus1/nodes.py
@@ -230,7 +230,7 @@ def node_windows_path_check(state: FlowState) -> dict:
         # like \n, \s, \t that happen to follow a colon (e.g. "Either:\n").
         import re as _re_detect
 
-        _DRIVE_DETECT_RE = _re_detect.compile(r"(?<![A-Za-z0-9_])([A-Za-z]):\\(?:[A-Za-z0-9_\-\. \\]+)")
+        _DRIVE_DETECT_RE = _re_detect.compile(r"(?<![A-Za-z0-9_])([A-Za-z]):\\(?:[A-Za-z0-9_][A-Za-z0-9_\-\. \\]+)")
         _path_files = list(project_root.glob("**/*.py"))
         if len(_path_files) > 500:
             _logger.warning("project_root has %d Python files (>500), capping scan at 500", len(_path_files))

--- a/langgraph_engine/level_minus1/recovery.py
+++ b/langgraph_engine/level_minus1/recovery.py
@@ -183,7 +183,7 @@ def ask_level_minus1_fix(state: FlowState) -> dict:
     message += "\n".join(failed_checks)
 
     if kb_suggestions:
-        message += "\n\n  KB SUGGESTIONS:/n"
+        message += "\n\n  KB SUGGESTIONS:\n"
         seen = set()
         for kb in kb_suggestions:
             sig = kb.get("signature", "")
@@ -191,7 +191,7 @@ def ask_level_minus1_fix(state: FlowState) -> dict:
                 seen.add(sig)
                 message += "    -> %s: %s\n" % (sig, kb.get("prevention", ""))
 
-    message += "\n\nOPTIONS:/n"
+    message += "\n\nOPTIONS:\n"
     message += "  1. auto-fix   -> Attempt repair + retry\n"
     message += "  2. skip       -> Continue anyway (NOT RECOMMENDED)\n"
 
@@ -314,7 +314,7 @@ def fix_level_minus1_issues(state: FlowState) -> dict:
             # Negative lookbehind (?<![A-Za-z0-9_]) ensures the drive letter is not preceded
             # by another word character, preventing false matches on escape sequences like
             # "Either:\n" (where 'r' would be mistaken for a drive letter).
-            _DRIVE_PATH_RE = _re_fix.compile(r"(?<![A-Za-z0-9_])([A-Za-z]):\\([\w\\. \-]+)")
+            _DRIVE_PATH_RE = _re_fix.compile(r"(?<![A-Za-z0-9_])([A-Za-z]):\\([A-Za-z0-9_][A-Za-z0-9_\-\. \\]+)")
 
             def _fix_drive_path(m):
                 drive = m.group(1)


### PR DESCRIPTION
## Summary

- **#229 — Regex still matches single-char escape sequences like `%d:\n`**: Strengthened the Windows path detection regex in `nodes.py` and the fix regex in `recovery.py`. The path segment immediately after `:\` must now begin with `[A-Za-z0-9_]` and be followed by **at least one more character**, so single-char escape sequences (`\n`, `\t`, `\s`, `\r`, `\d`) never match even when preceded by a non-word character like `%`. Real Windows path segments (e.g. `Users`, `workspace`, `techd`) are always 2+ chars and continue to match correctly.
- **#225 — `OPTIONS:/n` corrupt in `recovery.py`**: Two lines that were corrupted by the previous buggy auto-fix run (`KB SUGGESTIONS:/n` and `OPTIONS:/n`) are restored to proper Python newline escapes (`\n`).

## Files changed

| File | Change |
|------|--------|
| `langgraph_engine/level_minus1/nodes.py` | Detection regex: `(?:[A-Za-z0-9_\-\. \]+)` → `(?:[A-Za-z0-9_][A-Za-z0-9_\-\. \]+)` |
| `langgraph_engine/level_minus1/recovery.py` | Fix regex: `([\w\. \-]+)` → `([A-Za-z0-9_][A-Za-z0-9_\-\. \]+)`; restore two corrupted `\n` literals |

## Test plan

- [x] Inline regression tests run during implementation (9/9 passed):
  - `class Caller%d:\n` → does NOT match (was broken before, now fixed)
  - `C:\Users\techd` → matches
  - `D:\workspace` → matches
  - `Either:\n` → does NOT match (lookbehind)
  - `skill:\s*` → does NOT match (lookbehind)
  - `C:\Us` → matches (2-char segment)
  - `C:\n` → does NOT match (1-char segment)
  - `X:\t` → does NOT match (1-char segment)
  - `%C:\Users` → matches (real path after non-word char)
- [x] All pre-commit hooks passed (ruff, black, isort, check python ast)
- [ ] Run `pytest tests/test_level_minus1*.py` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)